### PR TITLE
feat(rules): add allowed_subfolders_rule

### DIFF
--- a/docs/content/docs/rules/_index.md
+++ b/docs/content/docs/rules/_index.md
@@ -74,6 +74,13 @@ Here you can find an overview of all possible rules. Use the filter below to fin
       <td><span class="rule-category-badge badge-manifest">Manifest</span></td>
       <td>Enforce a maximum line count for code. </td>
       <td style="font-size: 12px; color: #666;">code, lines, length, size, complexity</td>
+    </tr>
+    <tr class="rule-item" data-keywords="folder structure organization path subfolders hierarchy medallion bronze silver gold source" data-category="manifest">
+      <td><a href="allowed_subfolders" class="rule-name">allowed_subfolders</a></td>
+      <td><span class="rule-category-badge badge-manifest">Manifest</span></td>
+      <td>Enforce that objects are organized within specific allowed subfolders. Ensures consistent project structure and proper categorization by source or domain.</td>
+      <td style="font-size: 12px; color: #666;">folder, structure, organization, path, subfolders</td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/content/docs/rules/allowed_subfolders.md
+++ b/docs/content/docs/rules/allowed_subfolders.md
@@ -1,0 +1,162 @@
+---
+title: allowed_subfolders
+type: docs
+prev: docs/rules
+sidebar:
+  open: true
+---
+
+
+### Rule: `allowed_subfolders`
+
+<br>
+<details open>
+<summary>allowed_subfolders details</summary>
+<br>
+This rule enforces that dbt objects are organized within specific allowed subfolders of a given path. This helps maintain a consistent project structure and ensures models are properly categorized (e.g., by data source or domain).
+
+---
+
+**Configuration**
+
+- **type**: Must be `allowed_subfolders`.
+- **allowed_subfolders**: *(required)* List of subfolder names that are allowed within the specified path.
+- Both the `path_prefix` and `path_postfix` can be used to create this path `{path_prefix}/{resource_type}/{path_postfix}/`.
+  - **path_prefix**: *(optional)* Path segment that appears before the resource type (e.g., `dbt` for paths like `dbt/models/...`).
+  - **path_postfix**: *(optional)* Path segment that appears after the resource type (e.g., `bronze` for paths like `models/bronze/...`).
+- **applies_to**: *(optional)* List of dbt object types to include.
+  - Default: `["models"]`
+  - Options: `models`, `seeds`, `snapshots`, `analyses`, `metrics`, `hook_nodes`, `sql_operations`, `saved_queries`, `sources`, `unit_tests`, `macros`, `exposures`, `semantic_models`
+
+{{< include-markdown "content/snippets/common_rule_config.md" >}}
+
+**Example Config**
+
+{{< tabs items="dbtective.yml,dbtective.toml,pyproject.toml" >}}
+
+{{< tab >}}
+
+```yaml
+manifest_tests:
+  - name: "medallion_structure"
+    type: "allowed_subfolders"
+    description: "Models must follow medallion architecture (bronze/silver/gold)."
+    allowed_subfolders:
+      - "bronze"
+      - "silver"
+      - "gold"
+
+  - name: "bronze_models_by_source"
+    type: "allowed_subfolders"
+    description: "Bronze models must be organized by source system."
+    path_postfix: "bronze"
+    allowed_subfolders:
+      - "salesforce"
+      - "postgres"
+      - "snowflake"
+```
+
+{{< /tab >}}
+
+{{< tab >}}
+
+```toml
+[[manifest_tests]]
+name = "medallion_structure"
+type = "allowed_subfolders"
+description = "Models must follow medallion architecture (bronze/silver/gold)."
+applies_to = ["models"]
+allowed_subfolders = ["bronze", "silver", "gold"]
+
+[[manifest_tests]]
+name = "bronze_models_by_source"
+type = "allowed_subfolders"
+description = "Bronze models must be organized by source system."
+applies_to = ["models"]
+path_postfix = "bronze"
+allowed_subfolders = ["salesforce", "postgres", "snowflake"]
+```
+
+{{< /tab >}}
+
+{{< tab >}}
+
+```toml
+[[tool.dbtective.manifest_tests]]
+name = "medallion_structure"
+type = "allowed_subfolders"
+description = "Models must follow medallion architecture (bronze/silver/gold)."
+applies_to = ["models"]
+allowed_subfolders = ["bronze", "silver", "gold"]
+
+[[tool.dbtective.manifest_tests]]
+name = "bronze_models_by_source"
+type = "allowed_subfolders"
+description = "Bronze models must be organized by source system."
+applies_to = ["models"]
+path_postfix = "bronze"
+allowed_subfolders = ["salesforce", "postgres", "snowflake"]
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+<details closed>
+<summary>Relevant dbt structure</summary>
+
+The following example shows the expected folder structure enforced by the two rules above:
+
+- The `medallion_structure` rule ensures that models are organized into `bronze`, `silver`, and `gold` folders.
+- The `bronze_models_by_source` rule ensures that within the `bronze` folder, models are further organized by source system (e.g., `salesforce`, `postgres`, `snowflake`).
+
+This results in the following structure: <span style="color:#27ae60;font-weight:bold">✓ = compliant</span>, <span style="color:#e74c3c;font-weight:bold">✗ = non-compliant</span>
+
+{{< filetree/container >}}
+  {{< filetree/folder name="dbt_project" >}}
+    {{< filetree/folder name="models" >}}
+      {{< filetree/folder name="bronze" >}}
+        {{< filetree/folder name="salesforce ✓" state="open" >}}
+          {{< filetree/file name="stg_accounts.sql ✓" >}}
+        {{< /filetree/folder >}}
+        {{< filetree/folder name="postgres ✓" state="open" >}}
+          {{< filetree/file name="stg_users.sql ✓" >}}
+        {{< /filetree/folder >}}
+        {{< filetree/folder name="other_source ✗" state="open" >}}
+          {{< filetree/file name="stg_data.sql ✗ violates rule 2 (non-allowed subfolder)" >}}
+        {{< /filetree/folder >}}
+        {{< filetree/file name="stg_orders.sql ✗ violates rule 2 (root)" >}}
+      {{< /filetree/folder >}}
+      {{< filetree/folder name="silver" state="open" >}}
+        {{< filetree/file name="dim_customers.sql ✓" >}}
+      {{< /filetree/folder >}}
+    {{< /filetree/folder >}}
+  {{< /filetree/folder >}}
+{{< /filetree/container >}}
+
+</details>
+
+<!-- Find the ✓ and ✗ symbols and color them accordingly -->
+<style>
+.hextra-filetree-folder span:has-text("✓"),
+.hextra-filetree-folder .hx\:ltr\:ml-1:has-text("✓"),
+span.hx\:ltr\:ml-1.hx\:rtl\:mr-1 {
+  background: linear-gradient(to right, transparent 0%, transparent calc(100% - 1.2em), #27ae60 calc(100% - 1.2em), #27ae60 100%);
+  background-clip: text;
+  -webkit-background-clip: text;
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  // Color all ✓ symbols green
+  document.querySelectorAll('.hx\\:ltr\\:ml-1, .hx\\:rtl\\:mr-1').forEach(function(el) {
+    if (el.textContent.includes('✓')) {
+      el.innerHTML = el.innerHTML.replace(/✓/g, '<span style="color:#27ae60;font-weight:bold">✓</span>');
+    }
+    if (el.textContent.includes('✗')) {
+      el.innerHTML = el.innerHTML.replace(/✗/g, '<span style="color:#e74c3c;font-weight:bold">✗</span>');
+    }
+  });
+});
+</script>

--- a/src/core/config/manifest_rule.rs
+++ b/src/core/config/manifest_rule.rs
@@ -48,6 +48,13 @@ pub enum ManifestSpecificRuleConfig {
         #[serde(default = "default_max_code_lines")]
         max_lines: usize,
     },
+    AllowedSubfolders {
+        allowed_subfolders: Vec<String>,
+        #[serde(default)]
+        path_prefix: Option<String>,
+        #[serde(default)]
+        path_postfix: Option<String>,
+    },
 }
 
 impl ManifestSpecificRuleConfig {
@@ -266,10 +273,21 @@ pub fn default_applies_to_for_manifest_rule(rule_type: &ManifestSpecificRuleConf
             semantic_model_objects: vec![],
             custom_objects: vec![],
         },
+        // allowed_subfolders
+        ManifestSpecificRuleConfig::AllowedSubfolders { .. } => AppliesTo {
+            node_objects: vec![RuleTarget::Models],
+            source_objects: vec![],
+            unit_test_objects: vec![],
+            macro_objects: vec![],
+            exposure_objects: vec![],
+            semantic_model_objects: vec![],
+            custom_objects: vec![],
+        },
     }
 }
 
 // All options a user can choose
+#[allow(clippy::too_many_lines)]
 fn applies_to_options_for_manifest_rule(rule_type: &ManifestSpecificRuleConfig) -> AppliesTo {
     match rule_type {
         // has_description
@@ -367,6 +385,24 @@ fn applies_to_options_for_manifest_rule(rule_type: &ManifestSpecificRuleConfig) 
             source_objects: vec![],
             unit_test_objects: vec![],
             macro_objects: vec![],
+            exposure_objects: vec![RuleTarget::Exposures],
+            semantic_model_objects: vec![RuleTarget::SemanticModels],
+            custom_objects: vec![],
+        },
+        ManifestSpecificRuleConfig::AllowedSubfolders { .. } => AppliesTo {
+            node_objects: vec![
+                RuleTarget::Models,
+                RuleTarget::Seeds,
+                RuleTarget::Snapshots,
+                RuleTarget::Analyses,
+                RuleTarget::Metrics,
+                RuleTarget::HookNodes,
+                RuleTarget::SqlOperations,
+                RuleTarget::SavedQueries,
+            ],
+            source_objects: vec![RuleTarget::Sources],
+            unit_test_objects: vec![RuleTarget::UnitTests],
+            macro_objects: vec![RuleTarget::Macros],
             exposure_objects: vec![RuleTarget::Exposures],
             semantic_model_objects: vec![RuleTarget::SemanticModels],
             custom_objects: vec![],

--- a/src/core/manifest/exposure_impls.rs
+++ b/src/core/manifest/exposure_impls.rs
@@ -2,6 +2,7 @@
 use crate::core::config::applies_to::{RuleTarget, RuleTargetable};
 use crate::core::config::includes_excludes::IncludeExcludable;
 use crate::core::rules::common_traits::Identifiable;
+use crate::core::rules::rule_config::allowed_subfolders::PathCheckable;
 use crate::core::rules::rule_config::has_description::Descriptable;
 use crate::core::rules::rule_config::has_metadata_keys::HasMetadata;
 use crate::core::rules::rule_config::has_refs::CanReference;
@@ -66,5 +67,11 @@ impl CanReference for Exposure {
             Some(nodes) => nodes,
             None => &[],
         }
+    }
+}
+
+impl PathCheckable for Exposure {
+    fn get_rule_target(&self) -> RuleTarget {
+        self.ruletarget()
     }
 }

--- a/src/core/manifest/macro_impls.rs
+++ b/src/core/manifest/macro_impls.rs
@@ -2,6 +2,7 @@
 use crate::core::config::applies_to::{RuleTarget, RuleTargetable};
 use crate::core::config::includes_excludes::IncludeExcludable;
 use crate::core::rules::common_traits::Identifiable;
+use crate::core::rules::rule_config::allowed_subfolders::PathCheckable;
 use crate::core::rules::rule_config::has_description::Descriptable;
 use crate::core::rules::rule_config::has_metadata_keys::HasMetadata;
 use crate::core::rules::rule_config::max_code_lines::HasCode;
@@ -56,5 +57,11 @@ impl HasMetadata for Macro {
 impl HasCode for Macro {
     fn get_code(&self) -> Option<&str> {
         Some(&self.macro_sql)
+    }
+}
+
+impl PathCheckable for Macro {
+    fn get_rule_target(&self) -> RuleTarget {
+        self.ruletarget()
     }
 }

--- a/src/core/manifest/node_impls.rs
+++ b/src/core/manifest/node_impls.rs
@@ -3,6 +3,7 @@ use super::node_objects_impls::{AnalysisExt, ModelExt, SnapshotExt};
 use crate::core::config::applies_to::{RuleTarget, RuleTargetable};
 use crate::core::config::includes_excludes::IncludeExcludable;
 use crate::core::rules::common_traits::{Columnable, Identifiable};
+use crate::core::rules::rule_config::allowed_subfolders::PathCheckable;
 use crate::core::rules::rule_config::child_map::ChildMappable;
 use crate::core::rules::rule_config::has_contract_enforced::ContractAble;
 use crate::core::rules::rule_config::has_description::Descriptable;
@@ -83,6 +84,12 @@ impl Columnable for Node {
 impl IncludeExcludable for Node {
     fn get_relative_path(&self) -> &String {
         &self.get_base().original_file_path
+    }
+}
+
+impl PathCheckable for Node {
+    fn get_rule_target(&self) -> RuleTarget {
+        self.ruletarget()
     }
 }
 

--- a/src/core/manifest/semantic_model_impls.rs
+++ b/src/core/manifest/semantic_model_impls.rs
@@ -2,6 +2,7 @@
 use crate::core::config::applies_to::{RuleTarget, RuleTargetable};
 use crate::core::config::includes_excludes::IncludeExcludable;
 use crate::core::rules::common_traits::Identifiable;
+use crate::core::rules::rule_config::allowed_subfolders::PathCheckable;
 use crate::core::rules::rule_config::has_description::Descriptable;
 use crate::core::rules::rule_config::has_metadata_keys::HasMetadata;
 use crate::core::rules::rule_config::has_refs::CanReference;
@@ -59,5 +60,11 @@ impl CanReference for SemanticModel {
             Some(nodes) => nodes,
             None => &[],
         }
+    }
+}
+
+impl PathCheckable for SemanticModel {
+    fn get_rule_target(&self) -> RuleTarget {
+        self.ruletarget()
     }
 }

--- a/src/core/manifest/source_impls.rs
+++ b/src/core/manifest/source_impls.rs
@@ -2,6 +2,7 @@
 use crate::core::config::applies_to::{RuleTarget, RuleTargetable};
 use crate::core::config::includes_excludes::IncludeExcludable;
 use crate::core::rules::common_traits::{Columnable, Identifiable};
+use crate::core::rules::rule_config::allowed_subfolders::PathCheckable;
 use crate::core::rules::rule_config::child_map::ChildMappable;
 use crate::core::rules::rule_config::has_description::Descriptable;
 use crate::core::rules::rule_config::has_metadata_keys::HasMetadata;
@@ -104,5 +105,11 @@ impl TestAble for Source {
 impl HasMetadata for Source {
     fn get_metadata(&self) -> Option<&Meta> {
         self.meta.as_ref()
+    }
+}
+
+impl PathCheckable for Source {
+    fn get_rule_target(&self) -> RuleTarget {
+        self.ruletarget()
     }
 }

--- a/src/core/manifest/unit_test_impls.rs
+++ b/src/core/manifest/unit_test_impls.rs
@@ -2,6 +2,7 @@
 use crate::core::config::applies_to::{RuleTarget, RuleTargetable};
 use crate::core::config::includes_excludes::IncludeExcludable;
 use crate::core::rules::common_traits::Identifiable;
+use crate::core::rules::rule_config::allowed_subfolders::PathCheckable;
 use crate::core::rules::rule_config::has_description::Descriptable;
 use crate::core::rules::rule_config::name_convention::NameAble;
 use dbt_artifact_parser::manifest::UnitTest;
@@ -41,5 +42,11 @@ impl Descriptable for UnitTest {
 impl NameAble for UnitTest {
     fn name(&self) -> &str {
         self.get_name()
+    }
+}
+
+impl PathCheckable for UnitTest {
+    fn get_rule_target(&self) -> RuleTarget {
+        self.ruletarget()
     }
 }

--- a/src/core/rules/manifest/apply_manifest_node_rules.rs
+++ b/src/core/rules/manifest/apply_manifest_node_rules.rs
@@ -2,8 +2,9 @@ use crate::cli::table::RuleResult;
 use crate::core::config::applies_to::RuleTargetable;
 use crate::core::config::manifest_rule::ManifestSpecificRuleConfig;
 use crate::core::rules::rule_config::{
-    check_name_convention, child_map::is_not_orphaned, has_contract_enforced, has_description,
-    has_metadata_keys, has_refs, has_tags, has_unique_test, max_code_lines,
+    check_allowed_subfolders, check_name_convention, child_map::is_not_orphaned,
+    has_contract_enforced, has_description, has_metadata_keys, has_refs, has_tags, has_unique_test,
+    max_code_lines,
 };
 
 use crate::core::config::severity::Severity;
@@ -71,6 +72,17 @@ pub fn apply_manifest_node_rules<'a>(
                         max_code_lines(node, rule, *max_lines)
                     }
                     ManifestSpecificRuleConfig::HasRefs {} => has_refs(node, rule),
+                    ManifestSpecificRuleConfig::AllowedSubfolders {
+                        allowed_subfolders,
+                        path_prefix,
+                        path_postfix,
+                    } => check_allowed_subfolders(
+                        node,
+                        rule,
+                        allowed_subfolders,
+                        path_prefix.as_ref(),
+                        path_postfix.as_ref(),
+                    ),
                 };
 
                 if let Some(rule_row) = rule_row_result {

--- a/src/core/rules/manifest/apply_other_manifest_object_rules.rs
+++ b/src/core/rules/manifest/apply_other_manifest_object_rules.rs
@@ -1,7 +1,7 @@
 use crate::core::config::applies_to::RuleTargetable;
 use crate::core::rules::rule_config::{
-    check_name_convention, has_description, has_metadata_keys, has_refs, has_tags, has_unique_test,
-    is_not_orphaned, max_code_lines,
+    check_allowed_subfolders, check_name_convention, has_description, has_metadata_keys, has_refs,
+    has_tags, has_unique_test, is_not_orphaned, max_code_lines,
 };
 use crate::{
     cli::table::RuleResult,
@@ -83,11 +83,22 @@ fn apply_source_rules<'a>(
                         required_keys,
                         custom_message,
                     } => has_metadata_keys(source, rule, required_keys, custom_message.as_ref()),
+                    ManifestSpecificRuleConfig::AllowedSubfolders {
+                        allowed_subfolders,
+                        path_prefix,
+                        path_postfix,
+                    } => check_allowed_subfolders(
+                        source,
+                        rule,
+                        allowed_subfolders,
+                        path_prefix.as_ref(),
+                        path_postfix.as_ref(),
+                    ),
 
-                    // These can't be implemented for exposures
+                    // These can't be implemented for sources
                     ManifestSpecificRuleConfig::HasRefs {}
                     | ManifestSpecificRuleConfig::MaxCodeLines { .. }
-                    | ManifestSpecificRuleConfig::HasContractEnforced {} => return Ok(acc), // Models only
+                    | ManifestSpecificRuleConfig::HasContractEnforced {} => return Ok(acc),
                 };
 
                 if let Some(rule_row) = rule_row_result {
@@ -148,12 +159,23 @@ fn apply_macro_rules<'a>(
                         ManifestSpecificRuleConfig::MaxCodeLines { max_lines } => {
                             max_code_lines(macro_obj, rule, *max_lines)
                         }
+                        ManifestSpecificRuleConfig::AllowedSubfolders {
+                            allowed_subfolders,
+                            path_prefix,
+                            path_postfix,
+                        } => check_allowed_subfolders(
+                            macro_obj,
+                            rule,
+                            allowed_subfolders,
+                            path_prefix.as_ref(),
+                            path_postfix.as_ref(),
+                        ),
                         // These can't be implemented for macros
                         ManifestSpecificRuleConfig::HasTags { .. }
                         | ManifestSpecificRuleConfig::IsNotOrphaned { .. }
                         | ManifestSpecificRuleConfig::HasUniqueTest { .. }
                         | ManifestSpecificRuleConfig::HasRefs {}
-                        | ManifestSpecificRuleConfig::HasContractEnforced {} => return Ok(acc), //
+                        | ManifestSpecificRuleConfig::HasContractEnforced {} => return Ok(acc),
                     };
 
                     if let Some(rule_row) = rule_row_result {
@@ -217,6 +239,17 @@ fn apply_exposure_rules<'a>(
                             custom_message.as_ref(),
                         ),
                         ManifestSpecificRuleConfig::HasRefs {} => has_refs(exposure, rule),
+                        ManifestSpecificRuleConfig::AllowedSubfolders {
+                            allowed_subfolders,
+                            path_prefix,
+                            path_postfix,
+                        } => check_allowed_subfolders(
+                            exposure,
+                            rule,
+                            allowed_subfolders,
+                            path_prefix.as_ref(),
+                            path_postfix.as_ref(),
+                        ),
                         // These can't be implemented for exposures
                         ManifestSpecificRuleConfig::IsNotOrphaned { .. }
                         | ManifestSpecificRuleConfig::MaxCodeLines { .. }
@@ -273,6 +306,17 @@ fn apply_semantic_model_rules<'a>(
                         custom_message,
                     } => has_metadata_keys(sm, rule, required_keys, custom_message.as_ref()),
                     ManifestSpecificRuleConfig::HasRefs {} => has_refs(sm, rule),
+                    ManifestSpecificRuleConfig::AllowedSubfolders {
+                        allowed_subfolders,
+                        path_prefix,
+                        path_postfix,
+                    } => check_allowed_subfolders(
+                        sm,
+                        rule,
+                        allowed_subfolders,
+                        path_prefix.as_ref(),
+                        path_postfix.as_ref(),
+                    ),
                     // These can't be implemented for semantic models
                     ManifestSpecificRuleConfig::HasTags { .. }
                     | ManifestSpecificRuleConfig::MaxCodeLines { .. }
@@ -323,6 +367,17 @@ fn apply_unit_test_rules<'a>(
                     ManifestSpecificRuleConfig::NameConvention { convention } => {
                         check_name_convention(ut, rule, convention)
                     }
+                    ManifestSpecificRuleConfig::AllowedSubfolders {
+                        allowed_subfolders,
+                        path_prefix,
+                        path_postfix,
+                    } => check_allowed_subfolders(
+                        ut,
+                        rule,
+                        allowed_subfolders,
+                        path_prefix.as_ref(),
+                        path_postfix.as_ref(),
+                    ),
 
                     // Unit Tests do not implement the following rules
                     ManifestSpecificRuleConfig::MaxCodeLines { .. }

--- a/src/core/rules/rule_config/allowed_subfolders.rs
+++ b/src/core/rules/rule_config/allowed_subfolders.rs
@@ -1,0 +1,570 @@
+use crate::cli::table::RuleResult;
+use crate::core::config::applies_to::RuleTarget;
+use crate::core::config::manifest_rule::ManifestRule;
+use crate::core::rules::common_traits::Identifiable;
+
+/// Trait for objects that can be checked for allowed subfolders.
+/// Extends Identifiable to provide path information.
+pub trait PathCheckable: Identifiable {
+    fn get_rule_target(&self) -> RuleTarget;
+}
+
+pub fn check_allowed_subfolders<T: PathCheckable>(
+    item: &T,
+    rule: &ManifestRule,
+    allowed_subfolders: &[String],
+    path_prefix: Option<&String>,
+    path_postfix: Option<&String>,
+) -> Option<RuleResult> {
+    // Get the relative path from the object
+    let Some(raw_path) = item.get_relative_path() else {
+        return Some(RuleResult::new(
+            &rule.severity,
+            item.get_object_type(),
+            rule.get_name(),
+            format!(
+                "{} does not have a relative path; cannot check allowed subfolders.",
+                item.get_object_string()
+            ),
+            None,
+        ));
+    };
+
+    let normalized_path = normalize_path(raw_path);
+    let resource_type = item.get_rule_target().as_snake_case();
+    let base_path = build_base_path(resource_type, path_prefix, path_postfix);
+
+    // Check if the path starts with the base path
+    // If it doesn't, this rule doesn't apply to this file - pass (return None)
+    // e.g. /models/bronze/ doesnt apply to /models/silver/
+    if !normalized_path.starts_with(&base_path) {
+        return None;
+    }
+
+    // Extract the part after the base path
+    let remaining_path = &normalized_path[base_path.len()..];
+
+    // If there's no '/', the file is directly in the base path
+    if !remaining_path.contains('/') || remaining_path.is_empty() {
+        return Some(RuleResult::new(
+            &rule.severity,
+            item.get_object_type(),
+            rule.get_name(),
+            format!(
+                "{} is directly in '{}' but should be in one of the allowed subfolders: {}",
+                item.get_object_string(),
+                base_path,
+                allowed_subfolders.join(", ")
+            ),
+            item.get_relative_path().cloned(),
+        ));
+    }
+
+    // Split by '/' to get the immediate subfolder
+    let parts: Vec<&str> = remaining_path.split('/').collect();
+    let immediate_subfolder = parts[0];
+
+    if allowed_subfolders.contains(&immediate_subfolder.to_string()) {
+        None // Pass
+    } else {
+        Some(RuleResult::new(
+            &rule.severity,
+            item.get_object_type(),
+            rule.get_name(),
+            format!(
+                "{} is in subfolder '{}' these subfolders are allowed: {}",
+                item.get_object_string(),
+                immediate_subfolder,
+                allowed_subfolders.join(", ")
+            ),
+            item.get_relative_path().cloned(),
+        ))
+    }
+}
+
+/// Normalizes a path by converting backslashes to forward slashes
+/// and collapsing multiple consecutive slashes into single slashes.
+fn normalize_path(path: &str) -> String {
+    let mut normalized = path.replace('\\', "/");
+    while normalized.contains("//") {
+        normalized = normalized.replace("//", "/");
+    }
+    normalized
+}
+
+// Constructs the base path string based on resource type, optional prefix, and optional postfix.
+// Example: /{path_prefix/}models/{path_postfix/}bronze/
+fn build_base_path(
+    resource_type: &str,
+    path_prefix: Option<&String>,
+    path_postfix: Option<&String>,
+) -> String {
+    let mut base_path = String::new();
+
+    if let Some(prefix) = path_prefix {
+        base_path.push_str(&normalize_path(prefix));
+        if !base_path.ends_with('/') {
+            base_path.push('/');
+        }
+    }
+
+    base_path.push_str(resource_type);
+
+    if let Some(postfix) = path_postfix {
+        if !base_path.ends_with('/') {
+            base_path.push('/');
+        }
+        base_path.push_str(&normalize_path(postfix));
+    }
+
+    if !base_path.ends_with('/') {
+        base_path.push('/');
+    }
+
+    base_path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::{manifest_rule::ManifestSpecificRuleConfig, severity::Severity};
+
+    struct TestObject {
+        name: String,
+        path: String,
+        rule_target: RuleTarget,
+    }
+
+    impl Identifiable for TestObject {
+        fn get_object_type(&self) -> &'static str {
+            "TestObject"
+        }
+
+        fn get_object_string(&self) -> &str {
+            &self.name
+        }
+
+        fn get_relative_path(&self) -> Option<&String> {
+            Some(&self.path)
+        }
+    }
+
+    impl PathCheckable for TestObject {
+        fn get_rule_target(&self) -> RuleTarget {
+            self.rule_target.clone()
+        }
+    }
+
+    #[test]
+    fn test_allowed_subfolder_pass() {
+        let obj = TestObject {
+            name: "test_model".to_string(),
+            path: "models/bronze/source1/file.sql".to_string(),
+            rule_target: RuleTarget::Models,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec!["source1".to_string(), "source2".to_string()],
+                path_prefix: None,
+                path_postfix: Some("bronze".to_string()),
+            },
+            Severity::Error,
+        );
+
+        let result = check_allowed_subfolders(
+            &obj,
+            &rule,
+            &["source1".to_string(), "source2".to_string()],
+            None,
+            Some(&"bronze".to_string()),
+        );
+
+        assert_eq!(result, None, "Should pass - in allowed subfolder");
+    }
+
+    #[test]
+    fn test_allowed_subfolder_fail() {
+        let obj = TestObject {
+            name: "test_model".to_string(),
+            path: "models/bronze/source3/file.sql".to_string(),
+            rule_target: RuleTarget::Models,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec!["source1".to_string(), "source2".to_string()],
+                path_prefix: None,
+                path_postfix: Some("bronze".to_string()),
+            },
+            Severity::Error,
+        );
+
+        let result = check_allowed_subfolders(
+            &obj,
+            &rule,
+            &["source1".to_string(), "source2".to_string()],
+            None,
+            Some(&"bronze".to_string()),
+        );
+
+        assert!(result.is_some(), "Should fail - not in allowed subfolder");
+        let result = result.unwrap();
+        assert!(
+            result.message.contains("source3"),
+            "Message should mention the actual subfolder"
+        );
+        assert!(
+            result.message.contains("source1, source2"),
+            "Message should list allowed subfolders"
+        );
+    }
+
+    #[test]
+    fn test_with_path_prefix() {
+        let obj = TestObject {
+            name: "test_model".to_string(),
+            path: "dbt/models/bronze/source1/file.sql".to_string(),
+            rule_target: RuleTarget::Models,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec!["source1".to_string()],
+                path_prefix: Some("dbt".to_string()),
+                path_postfix: Some("bronze".to_string()),
+            },
+            Severity::Error,
+        );
+
+        let result = check_allowed_subfolders(
+            &obj,
+            &rule,
+            &["source1".to_string()],
+            Some(&"dbt".to_string()),
+            Some(&"bronze".to_string()),
+        );
+
+        assert_eq!(result, None, "Should pass with prefix");
+    }
+
+    #[test]
+    fn test_windows_backslash_paths() {
+        // Test that Windows-style backslash paths are normalized
+        let obj = TestObject {
+            name: "test_model".to_string(),
+            path: r"models\bronze\source1\file.sql".to_string(),
+            rule_target: RuleTarget::Models,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec!["source1".to_string()],
+                path_prefix: None,
+                path_postfix: Some("bronze".to_string()),
+            },
+            Severity::Error,
+        );
+
+        let result = check_allowed_subfolders(
+            &obj,
+            &rule,
+            &["source1".to_string()],
+            None,
+            Some(&"bronze".to_string()),
+        );
+
+        assert_eq!(
+            result, None,
+            "Should pass - Windows backslashes should be normalized"
+        );
+    }
+
+    #[test]
+    fn test_windows_mixed_slashes() {
+        // Test mixed slashes (Windows)
+        let obj = TestObject {
+            name: "test_model".to_string(),
+            path: r"models/bronze\source1/file.sql".to_string(),
+            rule_target: RuleTarget::Models,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec!["source1".to_string()],
+                path_prefix: None,
+                path_postfix: Some("bronze".to_string()),
+            },
+            Severity::Error,
+        );
+
+        let result = check_allowed_subfolders(
+            &obj,
+            &rule,
+            &["source1".to_string()],
+            None,
+            Some(&"bronze".to_string()),
+        );
+
+        assert_eq!(
+            result, None,
+            "Should pass - mixed slashes should be normalized"
+        );
+    }
+
+    #[test]
+    fn test_double_slashes() {
+        // Test double slashes in path
+        let obj = TestObject {
+            name: "test_model".to_string(),
+            path: "models//bronze//source1//file.sql".to_string(),
+            rule_target: RuleTarget::Models,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec!["source1".to_string()],
+                path_prefix: None,
+                path_postfix: Some("bronze".to_string()),
+            },
+            Severity::Error,
+        );
+        let result = check_allowed_subfolders(
+            &obj,
+            &rule,
+            &["source1".to_string()],
+            None,
+            Some(&"bronze".to_string()),
+        );
+        assert_eq!(
+            result, None,
+            "Should pass - double slashes should be handled correctly"
+        );
+    }
+
+    #[test]
+    fn test_no_prefix_or_postfix() {
+        let obj = TestObject {
+            name: "test_model".to_string(),
+            path: "models/bronze/file.sql".to_string(),
+            rule_target: RuleTarget::Models,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec!["bronze".to_string(), "silver".to_string()],
+                path_prefix: None,
+                path_postfix: None,
+            },
+            Severity::Error,
+        );
+
+        let result = check_allowed_subfolders(
+            &obj,
+            &rule,
+            &[
+                "bronze".to_string(),
+                "silver".to_string(),
+                "gold".to_string(),
+            ],
+            None,
+            None,
+        );
+
+        assert_eq!(result, None, "Should pass - models/bronze is allowed");
+    }
+
+    #[test]
+    fn test_different_resource_types() {
+        let seed = TestObject {
+            name: "test_seed".to_string(),
+            path: "seeds/bronze/source1/file.csv".to_string(),
+            rule_target: RuleTarget::Seeds,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec!["source1".to_string()],
+                path_prefix: None,
+                path_postfix: Some("bronze".to_string()),
+            },
+            Severity::Error,
+        );
+
+        let result = check_allowed_subfolders(
+            &seed,
+            &rule,
+            &["source1".to_string()],
+            None,
+            Some(&"bronze".to_string()),
+        );
+
+        assert_eq!(result, None, "Should pass - seeds have their own path");
+    }
+
+    #[test]
+    fn test_deep_nested_path() {
+        let obj = TestObject {
+            name: "test_model".to_string(),
+            path: "models/bronze/source1/subdir/deeper/file.sql".to_string(),
+            rule_target: RuleTarget::Models,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec!["source1".to_string()],
+                path_prefix: None,
+                path_postfix: Some("bronze".to_string()),
+            },
+            Severity::Error,
+        );
+
+        let result = check_allowed_subfolders(
+            &obj,
+            &rule,
+            &["source1".to_string()],
+            None,
+            Some(&"bronze".to_string()),
+        );
+
+        assert_eq!(
+            result, None,
+            "Should pass - deep nesting under allowed subfolder is ok"
+        );
+    }
+
+    #[test]
+    fn test_outside_base_path_ignored() {
+        // Files outside the base path should be ignored (pass)
+        let obj = TestObject {
+            name: "test_model".to_string(),
+            path: "models/silver/source1/file.sql".to_string(),
+            rule_target: RuleTarget::Models,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec!["source1".to_string()],
+                path_prefix: None,
+                path_postfix: Some("bronze".to_string()),
+            },
+            Severity::Error,
+        );
+
+        let result = check_allowed_subfolders(
+            &obj,
+            &rule,
+            &["source1".to_string()],
+            None,
+            Some(&"bronze".to_string()),
+        );
+
+        assert_eq!(
+            result, None,
+            "Should pass - file is not in base path (models/bronze/), so rule doesn't apply"
+        );
+    }
+
+    #[test]
+    fn test_intermediate_folder_ignored() {
+        // Test that models/intermediate/ is ignored when rule is for models/staging/
+        let obj = TestObject {
+            name: "int_model".to_string(),
+            path: "models/intermediate/finance/int_model.sql".to_string(),
+            rule_target: RuleTarget::Models,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec![
+                    "bronze".to_string(),
+                    "silver".to_string(),
+                    "gold".to_string(),
+                ],
+                path_prefix: None,
+                path_postfix: Some("staging".to_string()),
+            },
+            Severity::Error,
+        );
+
+        let result = check_allowed_subfolders(
+            &obj,
+            &rule,
+            &[
+                "bronze".to_string(),
+                "silver".to_string(),
+                "gold".to_string(),
+            ],
+            None,
+            Some(&"staging".to_string()),
+        );
+
+        assert_eq!(
+            result, None,
+            "Should pass - models/intermediate/ is not in base path (models/staging/)"
+        );
+    }
+
+    #[test]
+    fn test_marts_folder_ignored() {
+        // Test that models/marts/ is ignored when rule is for models/staging/
+        let obj = TestObject {
+            name: "customers".to_string(),
+            path: "models/marts/finance/customers.sql".to_string(),
+            rule_target: RuleTarget::Models,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec![
+                    "bronze".to_string(),
+                    "silver".to_string(),
+                    "gold".to_string(),
+                ],
+                path_prefix: None,
+                path_postfix: Some("staging".to_string()),
+            },
+            Severity::Error,
+        );
+
+        let result = check_allowed_subfolders(
+            &obj,
+            &rule,
+            &[
+                "bronze".to_string(),
+                "silver".to_string(),
+                "gold".to_string(),
+            ],
+            None,
+            Some(&"staging".to_string()),
+        );
+
+        assert_eq!(
+            result, None,
+            "Should pass - models/marts/ is not in base path (models/staging/)"
+        );
+    }
+
+    #[test]
+    fn test_directly_in_base_path_no_subfolder() {
+        let obj = TestObject {
+            name: "test_model".to_string(),
+            path: "models/bronze/file.sql".to_string(),
+            rule_target: RuleTarget::Models,
+        };
+        let rule = ManifestRule::from_specific_rule(
+            ManifestSpecificRuleConfig::AllowedSubfolders {
+                allowed_subfolders: vec!["source1".to_string(), "source2".to_string()],
+                path_prefix: None,
+                path_postfix: Some("bronze".to_string()),
+            },
+            Severity::Error,
+        );
+
+        let result = check_allowed_subfolders(
+            &obj,
+            &rule,
+            &["source1".to_string(), "source2".to_string()],
+            None,
+            Some(&"bronze".to_string()),
+        );
+
+        assert!(
+            result.is_some(),
+            "Should fail - file is directly in bronze without source1 or source2 subfolder"
+        );
+        let result = result.unwrap();
+        assert!(
+            result.message.contains("directly in"),
+            "Message should mention it's directly in the base path"
+        );
+    }
+}

--- a/src/core/rules/rule_config/mod.rs
+++ b/src/core/rules/rule_config/mod.rs
@@ -1,3 +1,4 @@
+pub mod allowed_subfolders;
 pub mod child_map;
 pub mod has_contract_enforced;
 pub mod has_description;
@@ -8,6 +9,7 @@ pub mod has_unique_test;
 pub mod max_code_lines;
 pub mod name_convention;
 
+pub use allowed_subfolders::check_allowed_subfolders;
 pub use child_map::is_not_orphaned;
 pub use has_contract_enforced::has_contract_enforced;
 pub use has_description::has_description;

--- a/tests/test_allowed_subfolders.rs
+++ b/tests/test_allowed_subfolders.rs
@@ -1,0 +1,663 @@
+mod common;
+
+use common::TestEnvironment;
+
+#[test]
+fn test_allowed_subfolder_pass() {
+    let manifest = r#"{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0"
+  },
+  "nodes": {
+    "model.test.stg_orders": {
+      "name": "stg_orders",
+      "resource_type": "model",
+      "path": "models/bronze/source1/stg_orders.sql",
+      "original_file_path": "models/bronze/source1/stg_orders.sql",
+      "unique_id": "model.test.stg_orders",
+      "description": "Test model",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "exposures": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}"#;
+
+    let config = r#"
+manifest_tests:
+  - name: "allowed_subfolders"
+    type: "allowed_subfolders"
+    severity: "error"
+    applies_to:
+      - "models"
+    path_postfix: "bronze"
+    allowed_subfolders:
+      - "source1"
+      - "source2"
+"#;
+
+    let env = TestEnvironment::new(manifest, config);
+    let findings = env.run_maniest_rules(false);
+
+    assert_eq!(
+        findings.len(),
+        0,
+        "Should pass - model is in allowed subfolder source1"
+    );
+}
+
+#[test]
+fn test_allowed_subfolder_fail() {
+    let manifest = r#"{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0"
+  },
+  "nodes": {
+    "model.test.stg_orders": {
+      "name": "stg_orders",
+      "resource_type": "model",
+      "path": "models/bronze/source3/stg_orders.sql",
+      "original_file_path": "models/bronze/source3/stg_orders.sql",
+      "unique_id": "model.test.stg_orders",
+      "description": "Test model",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "exposures": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}"#;
+
+    let config = r#"
+manifest_tests:
+  - name: "allowed_subfolders"
+    type: "allowed_subfolders"
+    severity: "error"
+    applies_to:
+      - "models"
+    path_postfix: "bronze"
+    allowed_subfolders:
+      - "source1"
+      - "source2"
+"#;
+
+    let env = TestEnvironment::new(manifest, config);
+    let findings = env.run_maniest_rules(false);
+
+    assert_eq!(findings.len(), 1, "Should fail - source3 is not allowed");
+    let finding = &findings[0].0;
+    assert!(
+        finding.message.contains("source3"),
+        "Error message should mention source3"
+    );
+}
+
+#[test]
+fn test_with_path_prefix() {
+    let manifest = r#"{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0"
+  },
+  "nodes": {
+    "model.test.stg_orders": {
+      "name": "stg_orders",
+      "resource_type": "model",
+      "path": "dbt/models/bronze/source1/stg_orders.sql",
+      "original_file_path": "dbt/models/bronze/source1/stg_orders.sql",
+      "unique_id": "model.test.stg_orders",
+      "description": "Test model",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "exposures": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}"#;
+
+    let config = r#"
+manifest_tests:
+  - name: "allowed_subfolders"
+    type: "allowed_subfolders"
+    severity: "error"
+    applies_to:
+      - "models"
+    path_prefix: "dbt"
+    path_postfix: "bronze"
+    allowed_subfolders:
+      - "source1"
+"#;
+
+    let env = TestEnvironment::new(manifest, config);
+    let findings = env.run_maniest_rules(false);
+
+    assert_eq!(findings.len(), 0, "Should pass with path_prefix");
+}
+
+#[test]
+fn test_no_prefix_or_postfix() {
+    let manifest = r#"{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0"
+  },
+  "nodes": {
+    "model.test.dim_customers": {
+      "name": "dim_customers",
+      "resource_type": "model",
+      "path": "models/bronze/dim_customers.sql",
+      "original_file_path": "models/bronze/dim_customers.sql",
+      "unique_id": "model.test.dim_customers",
+      "description": "Test model",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "exposures": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}"#;
+
+    let config = r#"
+manifest_tests:
+  - name: "allowed_subfolders"
+    type: "allowed_subfolders"
+    severity: "error"
+    applies_to:
+      - "models"
+    allowed_subfolders:
+      - "bronze"
+      - "silver"
+      - "gold"
+"#;
+
+    let env = TestEnvironment::new(manifest, config);
+    let findings = env.run_maniest_rules(false);
+
+    assert_eq!(findings.len(), 0, "Should pass - bronze is allowed");
+}
+
+#[test]
+fn test_directly_in_base_path_fails() {
+    let manifest = r#"{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0"
+  },
+  "nodes": {
+    "model.test.model": {
+      "name": "model",
+      "resource_type": "model",
+      "path": "models/bronze/model.sql",
+      "original_file_path": "models/bronze/model.sql",
+      "unique_id": "model.test.model",
+      "description": "Test model",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "exposures": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}"#;
+
+    let config = r#"
+manifest_tests:
+  - name: "allowed_subfolders"
+    type: "allowed_subfolders"
+    severity: "error"
+    applies_to:
+      - "models"
+    path_postfix: "bronze"
+    allowed_subfolders:
+      - "source1"
+      - "source2"
+"#;
+
+    let env = TestEnvironment::new(manifest, config);
+    let findings = env.run_maniest_rules(false);
+
+    assert_eq!(
+        findings.len(),
+        1,
+        "Should fail - file is directly in bronze without subfolder"
+    );
+    let finding = &findings[0].0;
+    assert!(
+        finding.message.contains("directly in"),
+        "Error message should mention 'directly in'"
+    );
+}
+
+#[test]
+fn test_deep_nested_path() {
+    let manifest = r#"{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0"
+  },
+  "nodes": {
+    "model.test.model": {
+      "name": "model",
+      "resource_type": "model",
+      "path": "models/bronze/source1/subdir/deeper/model.sql",
+      "original_file_path": "models/bronze/source1/subdir/deeper/model.sql",
+      "unique_id": "model.test.model",
+      "description": "Test model",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "exposures": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}"#;
+
+    let config = r#"
+manifest_tests:
+  - name: "allowed_subfolders"
+    type: "allowed_subfolders"
+    severity: "error"
+    applies_to:
+      - "models"
+    path_postfix: "bronze"
+    allowed_subfolders:
+      - "source1"
+"#;
+
+    let env = TestEnvironment::new(manifest, config);
+    let findings = env.run_maniest_rules(false);
+
+    assert_eq!(
+        findings.len(),
+        0,
+        "Should pass - deep nesting under allowed subfolder is ok"
+    );
+}
+
+#[test]
+fn test_outside_base_path_ignored() {
+    // Files outside the base path should be ignored
+    let manifest = r#"{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0"
+  },
+  "nodes": {
+    "model.test.model": {
+      "name": "model",
+      "resource_type": "model",
+      "path": "models/silver/source1/model.sql",
+      "original_file_path": "models/silver/source1/model.sql",
+      "unique_id": "model.test.model",
+      "description": "Test model",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "exposures": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}"#;
+
+    let config = r#"
+manifest_tests:
+  - name: "allowed_subfolders"
+    type: "allowed_subfolders"
+    severity: "error"
+    applies_to:
+      - "models"
+    path_postfix: "bronze"
+    allowed_subfolders:
+      - "source1"
+"#;
+
+    let env = TestEnvironment::new(manifest, config);
+    let findings = env.run_maniest_rules(false);
+
+    assert_eq!(
+        findings.len(),
+        0,
+        "Should pass - models/silver/ is not in base path (models/bronze/)"
+    );
+}
+
+#[test]
+fn test_intermediate_and_marts_ignored_when_rule_is_for_staging() {
+    // Test the medallion architecture scenario: rule applies to staging/, not intermediate/ or marts/
+    let manifest = r#"{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0"
+  },
+  "nodes": {
+    "model.test.stg_customers": {
+      "name": "stg_customers",
+      "resource_type": "model",
+      "path": "models/staging/bronze/stg_customers.sql",
+      "original_file_path": "models/staging/bronze/stg_customers.sql",
+      "unique_id": "model.test.stg_customers",
+      "description": "Staging model - should pass",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    },
+    "model.test.int_model": {
+      "name": "int_model",
+      "resource_type": "model",
+      "path": "models/intermediate/finance/int_model.sql",
+      "original_file_path": "models/intermediate/finance/int_model.sql",
+      "unique_id": "model.test.int_model",
+      "description": "Intermediate model - should be ignored",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    },
+    "model.test.customers": {
+      "name": "customers",
+      "resource_type": "model",
+      "path": "models/marts/finance/customers.sql",
+      "original_file_path": "models/marts/finance/customers.sql",
+      "unique_id": "model.test.customers",
+      "description": "Marts model - should be ignored",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "exposures": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}"#;
+
+    let config = r#"
+manifest_tests:
+  - name: "medallion_structure"
+    type: "allowed_subfolders"
+    severity: "error"
+    applies_to:
+      - "models"
+    path_postfix: "staging"
+    allowed_subfolders:
+      - "bronze"
+      - "silver"
+      - "gold"
+"#;
+
+    let env = TestEnvironment::new(manifest, config);
+    let findings = env.run_maniest_rules(false);
+
+    assert_eq!(
+        findings.len(),
+        0,
+        "Should pass - only staging/bronze/ model should be checked, intermediate/ and marts/ should be ignored"
+    );
+}
+
+#[test]
+fn test_staging_with_wrong_subfolder_fails() {
+    // Test that models in staging/ but with wrong subfolders fail
+    let manifest = r#"{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0"
+  },
+  "nodes": {
+    "model.test.stg_payments": {
+      "name": "stg_payments",
+      "resource_type": "model",
+      "path": "models/staging/crm/stg_payments.sql",
+      "original_file_path": "models/staging/crm/stg_payments.sql",
+      "unique_id": "model.test.stg_payments",
+      "description": "Staging model in wrong subfolder",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    },
+    "model.test.int_model": {
+      "name": "int_model",
+      "resource_type": "model",
+      "path": "models/intermediate/finance/int_model.sql",
+      "original_file_path": "models/intermediate/finance/int_model.sql",
+      "unique_id": "model.test.int_model",
+      "description": "Intermediate model - should be ignored",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "exposures": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}"#;
+
+    let config = r#"
+manifest_tests:
+  - name: "medallion_structure"
+    type: "allowed_subfolders"
+    severity: "error"
+    applies_to:
+      - "models"
+    path_postfix: "staging"
+    allowed_subfolders:
+      - "bronze"
+      - "silver"
+      - "gold"
+"#;
+
+    let env = TestEnvironment::new(manifest, config);
+    let findings = env.run_maniest_rules(false);
+
+    assert_eq!(
+        findings.len(),
+        1,
+        "Should fail - stg_payments is in staging/crm/ which is not allowed"
+    );
+    let finding = &findings[0].0;
+    assert!(
+        finding.message.contains("crm"),
+        "Error message should mention the wrong subfolder 'crm'"
+    );
+    assert!(
+        finding.message.contains("bronze, silver, gold"),
+        "Error message should mention allowed subfolders"
+    );
+}
+
+#[cfg(target_os = "windows")]
+mod windows_tests {
+    use super::*;
+
+    #[test]
+    fn test_windows_backslash_paths() {
+        let manifest = r#"{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0"
+  },
+  "nodes": {
+    "model.test.model": {
+      "name": "model",
+      "resource_type": "model",
+      "path": "models\\bronze\\source1\\model.sql",
+      "original_file_path": "models\\bronze\\source1\\model.sql",
+      "unique_id": "model.test.model",
+      "description": "Test model",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "exposures": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}"#;
+
+        let config = r#"
+manifest_tests:
+  - name: "allowed_subfolders"
+    type: "allowed_subfolders"
+    severity: "error"
+    applies_to:
+      - "models"
+    path_postfix: "bronze"
+    allowed_subfolders:
+      - "source1"
+"#;
+
+        let env = TestEnvironment::new(manifest, config);
+        let findings = env.run_maniest_rules(false);
+
+        assert_eq!(
+            findings.len(),
+            0,
+            "Windows backslash paths should be normalized and pass"
+        );
+    }
+
+    #[test]
+    fn test_windows_double_slashes() {
+        let manifest = r#"{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0"
+  },
+  "nodes": {
+    "model.test.model": {
+      "name": "model",
+      "resource_type": "model",
+      "path": "models\\\\bronze\\\\source1\\\\model.sql",
+      "original_file_path": "models\\\\bronze\\\\source1\\\\model.sql",
+      "unique_id": "model.test.model",
+      "description": "Test model",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "exposures": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}"#;
+
+        let config = r#"
+manifest_tests:
+  - name: "allowed_subfolders"
+    type: "allowed_subfolders"
+    severity: "error"
+    applies_to:
+      - "models"
+    path_postfix: "bronze"
+    allowed_subfolders:
+      - "source1"
+"#;
+
+        let env = TestEnvironment::new(manifest, config);
+        let findings = env.run_maniest_rules(false);
+
+        assert_eq!(
+            findings.len(),
+            0,
+            "Double slashes should be collapsed and normalized"
+        );
+    }
+
+    #[test]
+    fn test_windows_wrong_subfolder_fails() {
+        let manifest = r#"{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.10.0"
+  },
+  "nodes": {
+    "model.test.model": {
+      "name": "model",
+      "resource_type": "model",
+      "path": "models\\bronze\\source3\\model.sql",
+      "original_file_path": "models\\bronze\\source3\\model.sql",
+      "unique_id": "model.test.model",
+      "description": "Test model",
+      "config": {"materialized": "view"},
+      "raw_code": "SELECT 1"
+    }
+  },
+  "sources": {},
+  "macros": {},
+  "exposures": {},
+  "semantic_models": {},
+  "unit_tests": {},
+  "parent_map": {},
+  "child_map": {}
+}"#;
+
+        let config = r#"
+manifest_tests:
+  - name: "allowed_subfolders"
+    type: "allowed_subfolders"
+    severity: "error"
+    applies_to:
+      - "models"
+    path_postfix: "bronze"
+    allowed_subfolders:
+      - "source1"
+      - "source2"
+"#;
+
+        let env = TestEnvironment::new(manifest, config);
+        let findings = env.run_maniest_rules(false);
+
+        assert_eq!(
+            findings.len(),
+            1,
+            "Windows paths: wrong subfolder should fail"
+        );
+        let finding = &findings[0].0;
+        assert!(
+            finding.message.contains("source3"),
+            "Error message should mention source3"
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution to dbtective!
Please fill out this template to help us review your pull request.
-->



## Description
Closes:

Need to add documenttion still, but checking windows paths

todo:
- [ ]  Add documentation
- [ ] Change path parsing to earlier (once) in the config parsing (now it does it for every object), very ineffective
