### PR TITLE
fix: change catalog warning to stdout so it shows in prek/pre-commit

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -12,20 +12,20 @@ pub fn unwrap_or_exit<T>(result: anyhow::Result<T>) -> T {
 }
 
 pub fn print_catalog_warning() {
-    eprintln!(
+    println!(
         "\n{}{}",
         "One or more catalog tests failed. ".yellow().bold(),
         "This may be due to a stale catalog (local development, pre-commit).".yellow()
     );
 
-    eprintln!(
+    println!(
         "  {}",
         "Use --only-manifest everywhere except for CI/CD (recommended), or regenerate with `dbt docs generate`"
             .cyan()
             .dimmed()
     );
 
-    eprintln!(
+    println!(
         "  {}",
         "See: https://feliblo.github.io/dbtective/docs/running/precommit".dimmed()
     );


### PR DESCRIPTION
<!--
Thank you for your contribution to dbtective!
Please fill out this template to help us review your pull request.
-->

## Description
Closes:

<!--
- Clear title describing the change
- Detailed description of what was changed and why
-->

## Examples

## Checklist

- [x] I have followed the contribution guidelines
- [x] I have added/updated documentation as needed
- [x] I have added/updated tests as needed

## Additional Notes

<!--
Add any other context or screenshots here.
-->
