### PR TITLE
feat(bin): strip debug info for smaller binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,21 @@ remain = "0.2.15"
 
 [dev-dependencies]
 tempfile = "3.23.0"
-dbt_artifact_parser = { path = "dbt_artifact_parser", features = ["test-helpers"] }
+dbt_artifact_parser = { path = "dbt_artifact_parser", features = [
+    "test-helpers",
+] }
 
-# The profile that 'dist' will build with
-[profile.dist]
+
+[profile.release]
+debug = 0
+strip = true
+
+[profile.minimal-size]
 inherits = "release"
-lto = "thin"
+lto = "fat"
+codegen-units = 1
+strip = true
+panic = "abort"
+
+[profile.dist]
+inherits = "minimal-size"


### PR DESCRIPTION
<!--
Thank you for your contribution to dbtective!
Please fill out this template to help us review your pull request.
-->

## Description
Closes:

<!--
- Clear title describing the change
- Detailed description of what was changed and why
-->

## Examples

## Checklist

- [x] I have followed the contribution guidelines
- [x] I have added/updated documentation as needed
- [x] I have added/updated tests as needed

## Additional Notes

<!--
Add any other context or screenshots here.
-->
